### PR TITLE
Refactor residual .format()s to f-strings.

### DIFF
--- a/graphql/language/ast.py
+++ b/graphql/language/ast.py
@@ -83,7 +83,7 @@ class Location(NamedTuple):
 
     def __repr__(self):
         """Print a simplified form when appearing in repr() or inspect()."""
-        return "<Location {}:{}>".format(self.start, self.end)
+        return f"<Location {self.start}:{self.end}>"
 
     def __inspect__(self):
         return repr(self)

--- a/graphql/language/lexer.py
+++ b/graphql/language/lexer.py
@@ -61,7 +61,7 @@ class Token:
 
     def __repr__(self):
         """Print a simplified form when appearing in repr() or inspect()."""
-        return "<Token {} {}/{}>".format(self.desc, self.line, self.column)
+        return f"<Token {self.desc} {self.line}/{self.column}>"
 
     def __inspect__(self):
         return repr(self)


### PR DESCRIPTION
Replace .format() with f-strings in ast.py and lexer.py.