### PR TITLE
Use identity instead of hash for caching subfields in collect_subfields

### DIFF
--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -205,7 +205,7 @@ class ExecutionContext:
         self.middleware_manager = middleware_manager
         self.errors = errors
         self._subfields_cache: Dict[
-            Tuple[GraphQLObjectType, Tuple[FieldNode, ...]], Dict[str, List[FieldNode]]
+            Tuple[GraphQLObjectType, int], Dict[str, List[FieldNode]]
         ] = {}
 
     @classmethod
@@ -998,7 +998,7 @@ class ExecutionContext:
         subfields are not repeatedly calculated, which saves overhead when resolving
         lists of values.
         """
-        cache_key = return_type, tuple(field_nodes)
+        cache_key = return_type, id(field_nodes)
         sub_field_nodes = self._subfields_cache.get(cache_key)
         if sub_field_nodes is None:
             sub_field_nodes = {}


### PR DESCRIPTION
I've noticed computing `__hash__` on each cache access is quite expensive, and not what the JS implementation does - they are [caching subfield nodes](https://github.com/graphql/graphql-js/blob/e67f2e5515739295bad006ecde0e6ce5db0dc83d/src/execution/execute.js#L1105) based on [argument identity](https://github.com/graphql/graphql-js/blob/e67f2e5515739295bad006ecde0e6ce5db0dc83d/src/jsutils/memoize3.js).

This PR is based on #55 for the benchmarks, but it can work separately.

Results of `pytest --enable-benchmark -k benchmark` before and after the change:
```
------------------------------------------------------ benchmark: 1 tests ------------------------------------------------------
Name (time in s)                               Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------
benchmark_executing_introspection_query     1.1361  1.1782  1.1484  0.0170  1.1427  0.0152       1;1  0.8707       5           1
--------------------------------------------------------------------------------------------------------------------------------
```

```
---------------------------------------------------------- benchmark: 1 tests ----------------------------------------------------------
Name (time in ms)                                Min       Max      Mean  StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------
benchmark_executing_introspection_query     774.3004  789.3146  779.2556  6.0870  778.8992  7.2825       1;0  1.2833       5           1
----------------------------------------------------------------------------------------------------------------------------------------
```

this change also shaved 1/3 of the time from the benchmark mentioned in #54.