### PR TITLE
Add test for problem with coerce_input_value

### DIFF
--- a/tests/execution/test_variables.py
+++ b/tests/execution/test_variables.py
@@ -176,6 +176,22 @@ def describe_execute_handles_inputs():
                     None,
                 )
 
+            def properly_coerces_input_varaibles():
+                result = execute_query(
+                    """
+                    query FieldQuery($input: TestInputObject){
+                      fieldWithObjectInput(input: $input)
+                    }
+                    """,
+                    variable_values={"input": {'a': "foo", 'b': "bar", 'c': "baz"}}
+                )
+                assert result == (
+                    {
+                        'fieldWithObjectInput': "{'a': 'foo', 'b': ['bar'], 'c': 'baz'}"
+                    },
+                    None
+                )
+
             def properly_parses_null_value_to_null():
                 result = execute_query(
                     """


### PR DESCRIPTION
While working on graphql-python/graphene-django#812 I found that coerce_input_value will pollute the input value with every field of the type set to None. This will then fail in filtering.

I don't know where to fix that correctly. I "fixed" it like that:

```
a/src/graphql/utilities/coerce_input_value.py
```
```python
@@ -90,7 +90,7 @@ def coerce_input_value(
             field_value = input_value.get(field_name, INVALID)

             if field_value is INVALID:
-                if field.default_value is not INVALID:
+                if field.default_value not in (INVALID, None):
                     # Use out name as name if it exists (extension of GraphQL.js).
                     coerced_dict[field.out_name or field_name] = field.default_value
                 elif is_non_null_type(field.type):
```
Which is not correct, since the documentation says that it should be coerced to None. So the problem is actually a mismatch between expectations of the filter and how coerce_input_value is defined.

I appreciate any pointers or hints.