### PR TITLE
Fix TypeError while sorting errors in build_response

### DIFF
--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -315,7 +315,7 @@ class ExecutionContext:
             return ExecutionResult(data, None)
         # Sort the error list in order to make it deterministic, since we might have
         # been using parallel execution.
-        errors.sort(key=lambda error: (error.locations, error.path, error.message))
+        errors.sort(key=lambda error: (error.locations or [], error.path or [], error.message))
         return ExecutionResult(data, errors)
 
     def execute_operation(

--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -315,8 +315,9 @@ class ExecutionContext:
             return ExecutionResult(data, None)
         # Sort the error list in order to make it deterministic, since we might have
         # been using parallel execution.
-        errors.sort(key=lambda error: (
-            error.locations or [], error.path or [], error.message))
+        errors.sort(
+            key=lambda error: (error.locations or [], error.path or [], error.message)
+        )
         return ExecutionResult(data, errors)
 
     def execute_operation(

--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -315,7 +315,8 @@ class ExecutionContext:
             return ExecutionResult(data, None)
         # Sort the error list in order to make it deterministic, since we might have
         # been using parallel execution.
-        errors.sort(key=lambda error: (error.locations or [], error.path or [], error.message))
+        errors.sort(key=lambda error: (
+            error.locations or [], error.path or [], error.message))
         return ExecutionResult(data, errors)
 
     def execute_operation(


### PR DESCRIPTION
As GraphQLError objects might have 'None' as value for their 'locations' and 'path' attributes, a check must be placed in order to avoid raising a TypeError inside the errors list's 'sort' method. This commit changes None by an empty list to enable proper pairwise comparisons.