### PR TITLE
Use explicit optional type on arguments

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 python_version = 3.8
 check_untyped_defs = True
-no_implicit_optional = False
+no_implicit_optional = True
 strict_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True

--- a/src/graphql/error/graphql_error.py
+++ b/src/graphql/error/graphql_error.py
@@ -85,12 +85,12 @@ class GraphQLError(Exception):
     def __init__(
         self,
         message: str,
-        nodes: Union[Collection["Node"], "Node"] = None,
-        source: "Source" = None,
-        positions: Collection[int] = None,
-        path: Collection[Union[str, int]] = None,
-        original_error: Exception = None,
-        extensions: Dict[str, Any] = None,
+        nodes: Union[Collection["Node"], "Node", None] = None,
+        source: Optional["Source"] = None,
+        positions: Optional[Collection[int]] = None,
+        path: Optional[Collection[Union[str, int]]] = None,
+        original_error: Optional[Exception] = None,
+        extensions: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(message)
         self.message = message

--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -117,12 +117,12 @@ def execute(
     document: DocumentNode,
     root_value: Any = None,
     context_value: Any = None,
-    variable_values: Dict[str, Any] = None,
-    operation_name: str = None,
-    field_resolver: GraphQLFieldResolver = None,
-    type_resolver: GraphQLTypeResolver = None,
-    middleware: Middleware = None,
-    execution_context_class: Type["ExecutionContext"] = None,
+    variable_values: Optional[Dict[str, Any]] = None,
+    operation_name: Optional[str] = None,
+    field_resolver: Optional[GraphQLFieldResolver] = None,
+    type_resolver: Optional[GraphQLTypeResolver] = None,
+    middleware: Optional[Middleware] = None,
+    execution_context_class: Optional[Type["ExecutionContext"]] = None,
 ) -> AwaitableOrValue[ExecutionResult]:
     """Execute a GraphQL operation.
 
@@ -222,11 +222,11 @@ class ExecutionContext:
         document: DocumentNode,
         root_value: Any = None,
         context_value: Any = None,
-        raw_variable_values: Dict[str, Any] = None,
-        operation_name: str = None,
-        field_resolver: GraphQLFieldResolver = None,
-        type_resolver: GraphQLTypeResolver = None,
-        middleware: Middleware = None,
+        raw_variable_values: Optional[Dict[str, Any]] = None,
+        operation_name: Optional[str] = None,
+        field_resolver: Optional[GraphQLFieldResolver] = None,
+        type_resolver: Optional[GraphQLTypeResolver] = None,
+        middleware: Optional[Middleware] = None,
     ) -> Union[List[GraphQLError], "ExecutionContext"]:
         """Build an execution context
 
@@ -1030,7 +1030,7 @@ class ExecutionContext:
 def assert_valid_execution_arguments(
     schema: GraphQLSchema,
     document: DocumentNode,
-    raw_variable_values: Dict[str, Any] = None,
+    raw_variable_values: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Check that the arguments are acceptable.
 

--- a/src/graphql/execution/values.py
+++ b/src/graphql/execution/values.py
@@ -37,7 +37,7 @@ def get_variable_values(
     schema: GraphQLSchema,
     var_def_nodes: FrozenList[VariableDefinitionNode],
     inputs: Dict[str, Any],
-    max_errors: int = None,
+    max_errors: Optional[int] = None,
 ) -> CoercedVariableValues:
     """Get coerced variable values based on provided definitions.
 
@@ -144,7 +144,7 @@ def coerce_variable_values(
 def get_argument_values(
     type_def: Union[GraphQLField, GraphQLDirective],
     node: Union[FieldNode, DirectiveNode],
-    variable_values: Dict[str, Any] = None,
+    variable_values: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Get coerced argument values based on provided definitions and nodes.
 
@@ -221,7 +221,7 @@ NodeWithDirective = Union[
 def get_directive_values(
     directive_def: GraphQLDirective,
     node: NodeWithDirective,
-    variable_values: Dict[str, Any] = None,
+    variable_values: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Get coerced argument values based on provided nodes.
 

--- a/src/graphql/graphql.py
+++ b/src/graphql/graphql.py
@@ -1,6 +1,6 @@
 from asyncio import ensure_future
 from inspect import isawaitable
-from typing import Any, Awaitable, Dict, Union, Type, cast
+from typing import Any, Awaitable, Dict, Optional, Union, Type, cast
 
 from .error import GraphQLError
 from .execution import execute, ExecutionResult, ExecutionContext, Middleware
@@ -21,11 +21,11 @@ async def graphql(
     source: Union[str, Source],
     root_value: Any = None,
     context_value: Any = None,
-    variable_values: Dict[str, Any] = None,
-    operation_name: str = None,
-    field_resolver: GraphQLFieldResolver = None,
-    type_resolver: GraphQLTypeResolver = None,
-    middleware: Middleware = None,
+    variable_values: Optional[Dict[str, Any]] = None,
+    operation_name: Optional[str] = None,
+    field_resolver: Optional[GraphQLFieldResolver] = None,
+    type_resolver: Optional[GraphQLTypeResolver] = None,
+    middleware: Optional[Middleware] = None,
     execution_context_class: Type[ExecutionContext] = ExecutionContext,
 ) -> ExecutionResult:
     """Execute a GraphQL operation asynchronously.
@@ -95,11 +95,11 @@ def graphql_sync(
     source: Union[str, Source],
     root_value: Any = None,
     context_value: Any = None,
-    variable_values: Dict[str, Any] = None,
-    operation_name: str = None,
-    field_resolver: GraphQLFieldResolver = None,
-    type_resolver: GraphQLTypeResolver = None,
-    middleware: Middleware = None,
+    variable_values: Optional[Dict[str, Any]] = None,
+    operation_name: Optional[str] = None,
+    field_resolver: Optional[GraphQLFieldResolver] = None,
+    type_resolver: Optional[GraphQLTypeResolver] = None,
+    middleware: Optional[Middleware] = None,
     execution_context_class: Type[ExecutionContext] = ExecutionContext,
 ) -> ExecutionResult:
     """Execute a GraphQL operation synchronously.

--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -93,8 +93,8 @@ class Token:
         end: int,
         line: int,
         column: int,
-        prev: "Token" = None,
-        value: str = None,
+        prev: Optional["Token"] = None,
+        value: Optional[str] = None,
     ) -> None:
         self.kind = kind
         self.start, self.end = start, end

--- a/src/graphql/language/parser.py
+++ b/src/graphql/language/parser.py
@@ -1025,7 +1025,7 @@ class Parser:
 
         return False
 
-    def unexpected(self, at_token: Token = None) -> GraphQLError:
+    def unexpected(self, at_token: Optional[Token] = None) -> GraphQLError:
         """Create an error when an unexpected lexed token is encountered."""
         token = at_token or self._lexer.token
         return GraphQLSyntaxError(

--- a/src/graphql/language/source.py
+++ b/src/graphql/language/source.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from .location import SourceLocation
 
 __all__ = ["Source"]
@@ -9,7 +11,10 @@ class Source:
     __slots__ = "body", "name", "location_offset"
 
     def __init__(
-        self, body: str, name: str = None, location_offset: SourceLocation = None
+        self,
+        body: str,
+        name: Optional[str] = None,
+        location_offset: Optional[SourceLocation] = None,
     ) -> None:
         """Initialize source input.
 

--- a/src/graphql/pyutils/did_you_mean.py
+++ b/src/graphql/pyutils/did_you_mean.py
@@ -1,11 +1,11 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 __all__ = ["did_you_mean"]
 
 MAX_LENGTH = 5
 
 
-def did_you_mean(suggestions: Sequence[str], sub_message: str = None) -> str:
+def did_you_mean(suggestions: Sequence[str], sub_message: Optional[str] = None) -> str:
     """Given [ A, B, C ] return ' Did you mean A, B, or C?'"""
     if not suggestions:
         return ""

--- a/src/graphql/subscription/map_async_iterator.py
+++ b/src/graphql/subscription/map_async_iterator.py
@@ -1,7 +1,7 @@
 from asyncio import Event, ensure_future, Future, wait
 from concurrent.futures import FIRST_COMPLETED
 from inspect import isasyncgen, isawaitable
-from typing import AsyncIterable, Callable, Set
+from typing import AsyncIterable, Callable, Optional, Set
 
 __all__ = ["MapAsyncIterator"]
 
@@ -21,7 +21,7 @@ class MapAsyncIterator:
         self,
         iterable: AsyncIterable,
         callback: Callable,
-        reject_callback: Callable = None,
+        reject_callback: Optional[Callable] = None,
     ) -> None:
         self.iterator = iterable.__aiter__()
         self.callback = callback

--- a/src/graphql/subscription/subscribe.py
+++ b/src/graphql/subscription/subscribe.py
@@ -1,5 +1,14 @@
 from inspect import isawaitable
-from typing import Any, AsyncIterable, AsyncIterator, Awaitable, Dict, Union, cast
+from typing import (
+    Any,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
+    Dict,
+    Optional,
+    Union,
+    cast,
+)
 
 from ..error import GraphQLError, located_error
 from ..execution.execute import (
@@ -23,10 +32,10 @@ async def subscribe(
     document: DocumentNode,
     root_value: Any = None,
     context_value: Any = None,
-    variable_values: Dict[str, Any] = None,
-    operation_name: str = None,
-    field_resolver: GraphQLFieldResolver = None,
-    subscribe_field_resolver: GraphQLFieldResolver = None,
+    variable_values: Optional[Dict[str, Any]] = None,
+    operation_name: Optional[str] = None,
+    field_resolver: Optional[GraphQLFieldResolver] = None,
+    subscribe_field_resolver: Optional[GraphQLFieldResolver] = None,
 ) -> Union[AsyncIterator[ExecutionResult], ExecutionResult]:
     """Create a GraphQL subscription.
 
@@ -91,9 +100,9 @@ async def create_source_event_stream(
     document: DocumentNode,
     root_value: Any = None,
     context_value: Any = None,
-    variable_values: Dict[str, Any] = None,
-    operation_name: str = None,
-    field_resolver: GraphQLFieldResolver = None,
+    variable_values: Optional[Dict[str, Any]] = None,
+    operation_name: Optional[str] = None,
+    field_resolver: Optional[GraphQLFieldResolver] = None,
 ) -> Union[AsyncIterable[Any], ExecutionResult]:
     """Create source even stream
 

--- a/src/graphql/type/definition.py
+++ b/src/graphql/type/definition.py
@@ -198,10 +198,10 @@ class GraphQLNamedType(GraphQLType):
     def __init__(
         self,
         name: str,
-        description: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: TypeDefinitionNode = None,
-        extension_ast_nodes: Collection[TypeExtensionNode] = None,
+        description: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[TypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[TypeExtensionNode]] = None,
     ) -> None:
         if not name:
             raise TypeError("Must provide name.")
@@ -322,13 +322,13 @@ class GraphQLScalarType(GraphQLNamedType):
     def __init__(
         self,
         name: str,
-        serialize: GraphQLScalarSerializer = None,
-        parse_value: GraphQLScalarValueParser = None,
-        parse_literal: GraphQLScalarLiteralParser = None,
-        description: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: ScalarTypeDefinitionNode = None,
-        extension_ast_nodes: Collection[ScalarTypeExtensionNode] = None,
+        serialize: Optional[GraphQLScalarSerializer] = None,
+        parse_value: Optional[GraphQLScalarValueParser] = None,
+        parse_literal: Optional[GraphQLScalarLiteralParser] = None,
+        description: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[ScalarTypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[ScalarTypeExtensionNode]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -392,7 +392,9 @@ class GraphQLScalarType(GraphQLNamedType):
         """
         return value
 
-    def parse_literal(self, node: ValueNode, _variables: Dict[str, Any] = None) -> Any:
+    def parse_literal(
+        self, node: ValueNode, _variables: Optional[Dict[str, Any]] = None
+    ) -> Any:
         """Parses an externally provided literal value to use as an input.
 
         This default method uses the parse_value method and should be replaced
@@ -444,13 +446,13 @@ class GraphQLField:
     def __init__(
         self,
         type_: "GraphQLOutputType",
-        args: GraphQLArgumentMap = None,
-        resolve: "GraphQLFieldResolver" = None,
-        subscribe: "GraphQLFieldResolver" = None,
-        description: str = None,
-        deprecation_reason: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: FieldDefinitionNode = None,
+        args: Optional[GraphQLArgumentMap] = None,
+        resolve: Optional["GraphQLFieldResolver"] = None,
+        subscribe: Optional["GraphQLFieldResolver"] = None,
+        description: Optional[str] = None,
+        deprecation_reason: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[FieldDefinitionNode] = None,
     ) -> None:
         if not is_output_type(type_):
             raise TypeError("Field type must be an output type.")
@@ -588,10 +590,10 @@ class GraphQLArgument:
         self,
         type_: "GraphQLInputType",
         default_value: Any = Undefined,
-        description: str = None,
-        out_name: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: InputValueDefinitionNode = None,
+        description: Optional[str] = None,
+        out_name: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[InputValueDefinitionNode] = None,
     ) -> None:
         if not is_input_type(type_):
             raise TypeError(f"Argument type must be a GraphQL input type.")
@@ -682,12 +684,12 @@ class GraphQLObjectType(GraphQLNamedType):
         self,
         name: str,
         fields: Thunk[GraphQLFieldMap],
-        interfaces: Thunk[Collection["GraphQLInterfaceType"]] = None,
-        is_type_of: GraphQLIsTypeOfFn = None,
-        extensions: Dict[str, Any] = None,
-        description: str = None,
-        ast_node: ObjectTypeDefinitionNode = None,
-        extension_ast_nodes: Collection[ObjectTypeExtensionNode] = None,
+        interfaces: Optional[Thunk[Collection["GraphQLInterfaceType"]]] = None,
+        is_type_of: Optional[GraphQLIsTypeOfFn] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+        ast_node: Optional[ObjectTypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[ObjectTypeExtensionNode]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -801,13 +803,13 @@ class GraphQLInterfaceType(GraphQLNamedType):
     def __init__(
         self,
         name: str,
-        fields: Thunk[GraphQLFieldMap] = None,
-        interfaces: Thunk[Collection["GraphQLInterfaceType"]] = None,
-        resolve_type: GraphQLTypeResolver = None,
-        description: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: InterfaceTypeDefinitionNode = None,
-        extension_ast_nodes: Collection[InterfaceTypeExtensionNode] = None,
+        fields: Optional[Thunk[GraphQLFieldMap]] = None,
+        interfaces: Optional[Thunk[Collection["GraphQLInterfaceType"]]] = None,
+        resolve_type: Optional[GraphQLTypeResolver] = None,
+        description: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[InterfaceTypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[InterfaceTypeExtensionNode]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -927,11 +929,11 @@ class GraphQLUnionType(GraphQLNamedType):
         self,
         name,
         types: Thunk[Collection[GraphQLObjectType]],
-        resolve_type: GraphQLTypeResolver = None,
-        description: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: UnionTypeDefinitionNode = None,
-        extension_ast_nodes: Collection[UnionTypeExtensionNode] = None,
+        resolve_type: Optional[GraphQLTypeResolver] = None,
+        description: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[UnionTypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[UnionTypeExtensionNode]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -1033,10 +1035,10 @@ class GraphQLEnumType(GraphQLNamedType):
         self,
         name: str,
         values: Union[GraphQLEnumValueMap, Dict[str, Any], Type[Enum]],
-        description: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: EnumTypeDefinitionNode = None,
-        extension_ast_nodes: Collection[EnumTypeExtensionNode] = None,
+        description: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[EnumTypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[EnumTypeExtensionNode]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -1119,7 +1121,7 @@ class GraphQLEnumType(GraphQLNamedType):
         return Undefined
 
     def parse_literal(
-        self, value_node: ValueNode, _variables: Dict[str, Any] = None
+        self, value_node: ValueNode, _variables: Optional[Dict[str, Any]] = None
     ) -> Any:
         # Note: variables will be resolved before calling this method.
         if isinstance(value_node, EnumValueNode):
@@ -1155,10 +1157,10 @@ class GraphQLEnumValue:
     def __init__(
         self,
         value: Any = None,
-        description: str = None,
-        deprecation_reason: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: EnumValueDefinitionNode = None,
+        description: Optional[str] = None,
+        deprecation_reason: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[EnumValueDefinitionNode] = None,
     ) -> None:
         if description is not None and not is_description(description):
             raise TypeError("The description of the enum value must be a string.")
@@ -1240,11 +1242,11 @@ class GraphQLInputObjectType(GraphQLNamedType):
         self,
         name: str,
         fields: Thunk[GraphQLInputFieldMap],
-        description: str = None,
-        out_type: GraphQLInputFieldOutType = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: InputObjectTypeDefinitionNode = None,
-        extension_ast_nodes: Collection[InputObjectTypeExtensionNode] = None,
+        description: Optional[str] = None,
+        out_type: Optional[GraphQLInputFieldOutType] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[InputObjectTypeDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[InputObjectTypeExtensionNode]] = None,
     ) -> None:
         super().__init__(
             name=name,
@@ -1342,10 +1344,10 @@ class GraphQLInputField:
         self,
         type_: "GraphQLInputType",
         default_value: Any = Undefined,
-        description: str = None,
-        out_name: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: InputValueDefinitionNode = None,
+        description: Optional[str] = None,
+        out_name: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[InputValueDefinitionNode] = None,
     ) -> None:
         if not is_input_type(type_):
             raise TypeError(f"Input field type must be a GraphQL input type.")

--- a/src/graphql/type/directives.py
+++ b/src/graphql/type/directives.py
@@ -38,11 +38,11 @@ class GraphQLDirective:
         self,
         name: str,
         locations: Collection[DirectiveLocation],
-        args: Dict[str, GraphQLArgument] = None,
+        args: Optional[Dict[str, GraphQLArgument]] = None,
         is_repeatable: bool = False,
-        description: str = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: ast.DirectiveDefinitionNode = None,
+        description: Optional[str] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[ast.DirectiveDefinitionNode] = None,
     ) -> None:
         if not name:
             raise TypeError("Directive must be named.")

--- a/src/graphql/type/schema.py
+++ b/src/graphql/type/schema.py
@@ -104,14 +104,14 @@ class GraphQLSchema:
 
     def __init__(
         self,
-        query: GraphQLObjectType = None,
-        mutation: GraphQLObjectType = None,
-        subscription: GraphQLObjectType = None,
-        types: Collection[GraphQLNamedType] = None,
-        directives: Collection[GraphQLDirective] = None,
-        extensions: Dict[str, Any] = None,
-        ast_node: ast.SchemaDefinitionNode = None,
-        extension_ast_nodes: Collection[ast.SchemaExtensionNode] = None,
+        query: Optional[GraphQLObjectType] = None,
+        mutation: Optional[GraphQLObjectType] = None,
+        subscription: Optional[GraphQLObjectType] = None,
+        types: Optional[Collection[GraphQLNamedType]] = None,
+        directives: Optional[Collection[GraphQLDirective]] = None,
+        extensions: Optional[Dict[str, Any]] = None,
+        ast_node: Optional[ast.SchemaDefinitionNode] = None,
+        extension_ast_nodes: Optional[Collection[ast.SchemaExtensionNode]] = None,
         assume_valid: bool = False,
     ) -> None:
         """Initialize GraphQL schema.
@@ -297,7 +297,7 @@ class GraphQLSchema:
         return self._validation_errors
 
     def type_map_reducer(
-        self, map_: TypeMap, type_: GraphQLNamedType = None
+        self, map_: TypeMap, type_: Optional[GraphQLNamedType] = None
     ) -> TypeMap:
         """Reducer function for creating the type map from given types."""
         if not type_:
@@ -336,7 +336,7 @@ class GraphQLSchema:
         return map_
 
     def type_map_directive_reducer(
-        self, map_: TypeMap, directive: GraphQLDirective = None
+        self, map_: TypeMap, directive: Optional[GraphQLDirective] = None
     ) -> TypeMap:
         """Reducer function for creating the type map from given directives."""
         # Directives are not validated until validate_schema() is called.

--- a/src/graphql/type/validate.py
+++ b/src/graphql/type/validate.py
@@ -164,7 +164,7 @@ class SchemaValidationContext:
                         arg.ast_node,
                     )
 
-    def validate_name(self, node: Any, name: str = None) -> None:
+    def validate_name(self, node: Any, name: Optional[str] = None) -> None:
         # Ensure names are valid, however introspection types opt out.
         try:
             if not name:

--- a/src/graphql/utilities/assert_valid_name.py
+++ b/src/graphql/utilities/assert_valid_name.py
@@ -18,7 +18,9 @@ def assert_valid_name(name: str) -> str:
     return name
 
 
-def is_valid_name_error(name: str, node: Node = None) -> Optional[GraphQLError]:
+def is_valid_name_error(
+    name: str, node: Optional[Node] = None
+) -> Optional[GraphQLError]:
     """Return an Error if a name is invalid."""
     if not isinstance(name, str):
         raise TypeError("Expected name to be a string.")

--- a/src/graphql/utilities/coerce_input_value.py
+++ b/src/graphql/utilities/coerce_input_value.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterable, List, Union, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union, cast
 
 
 from ..error import GraphQLError
@@ -44,7 +44,7 @@ def coerce_input_value(
     input_value: Any,
     type_: GraphQLInputType,
     on_error: OnErrorCB = default_on_error,
-    path: Path = None,
+    path: Optional[Path] = None,
 ) -> Any:
     """Coerce a Python value given a GraphQL Input Type."""
     if is_non_null_type(type_):

--- a/src/graphql/utilities/type_info.py
+++ b/src/graphql/utilities/type_info.py
@@ -62,8 +62,8 @@ class TypeInfo:
     def __init__(
         self,
         schema: GraphQLSchema,
-        get_field_def_fn: GetFieldDefType = None,
-        initial_type: GraphQLType = None,
+        get_field_def_fn: Optional[GetFieldDefType] = None,
+        initial_type: Optional[GraphQLType] = None,
     ) -> None:
         """Initialize the TypeInfo for the given GraphQL schema.
 

--- a/src/graphql/utilities/value_from_ast.py
+++ b/src/graphql/utilities/value_from_ast.py
@@ -29,7 +29,7 @@ __all__ = ["value_from_ast"]
 def value_from_ast(
     value_node: Optional[ValueNode],
     type_: GraphQLInputType,
-    variables: Dict[str, Any] = None,
+    variables: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """Produce a Python value given a GraphQL Value AST.
 
@@ -157,7 +157,7 @@ def value_from_ast(
 
 
 def is_missing_variable(
-    value_node: ValueNode, variables: Dict[str, Any] = None
+    value_node: ValueNode, variables: Optional[Dict[str, Any]] = None
 ) -> bool:
     """Check if `value_node` is a variable not defined in the `variables` dict."""
     return isinstance(value_node, VariableNode) and (

--- a/src/graphql/utilities/value_from_ast_untyped.py
+++ b/src/graphql/utilities/value_from_ast_untyped.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from ..language import ValueNode
 from ..pyutils import inspect, is_invalid, Undefined
@@ -7,7 +7,7 @@ __all__ = ["value_from_ast_untyped"]
 
 
 def value_from_ast_untyped(
-    value_node: ValueNode, variables: Dict[str, Any] = None
+    value_node: ValueNode, variables: Optional[Dict[str, Any]] = None
 ) -> Any:
     """Produce a Python value given a GraphQL Value AST.
 

--- a/src/graphql/validation/validate.py
+++ b/src/graphql/validation/validate.py
@@ -1,4 +1,4 @@
-from typing import Collection, List
+from typing import Collection, List, Optional
 
 from ..error import GraphQLError
 from ..language import DocumentNode, ParallelVisitor, visit
@@ -19,9 +19,9 @@ class ValidationAbortedError(RuntimeError):
 def validate(
     schema: GraphQLSchema,
     document_ast: DocumentNode,
-    rules: Collection[RuleType] = None,
-    type_info: TypeInfo = None,
-    max_errors: int = None,
+    rules: Optional[Collection[RuleType]] = None,
+    type_info: Optional[TypeInfo] = None,
+    max_errors: Optional[int] = None,
 ) -> List[GraphQLError]:
     """Implements the "Validation" section of the spec.
 
@@ -82,8 +82,8 @@ def validate(
 
 def validate_sdl(
     document_ast: DocumentNode,
-    schema_to_extend: GraphQLSchema = None,
-    rules: Collection[RuleType] = None,
+    schema_to_extend: Optional[GraphQLSchema] = None,
+    rules: Optional[Collection[RuleType]] = None,
 ) -> List[GraphQLError]:
     """Validate an SDL document.
 

--- a/tests/execution/test_union_interface.py
+++ b/tests/execution/test_union_interface.py
@@ -55,8 +55,8 @@ class Person:
     def __init__(
         self,
         name: str,
-        pets: List[Union[Dog, Cat]] = None,
-        friends: List[Union[Dog, Cat, "Person"]] = None,
+        pets: Optional[List[Union[Dog, Cat]]] = None,
+        friends: Optional[List[Union[Dog, Cat, "Person"]]] = None,
     ):
         self.name = name
         self.pets = pets


### PR DESCRIPTION
This allows the type checks with `mypy` to pass in strict mode.

The reason for this is that we run type checks with `mypy` using the `--strict` mode which includes `no_implicit_optional`. This means that calls like e.g.

```py
async def some_wrapper() -> ExecutionResult:
    schema: GraphQLSchema = ...
    query: str = ...
    variables: Optional[Dict[str, Any]] = ...
    return await graphql(schema, query, variable_values=variables)
```
fill fail the check with an error
```
src/mod.py:XXX: error: Argument "variable_values" to "graphql" has incompatible type "Optional[Dict[str, Any]]"; expected "Dict[str, Any]"
```
A possible workaround would be maintaining a private set of type stubs for the `graphql` package with optional types wrapped into `Optional`.

If you find the suggestion useful, I can extend this to the whole codebase. Of course, I understand that e.g.

```py
def execute(
    schema: GraphQLSchema,
    document: DocumentNode,
    root_value: Any = None,
    context_value: Any = None,
    variable_values: Optional[Dict[str, Any]] = None,
    operation_name: Optional[str] = None,
    field_resolver: Optional[GraphQLFieldResolver] = None,
    type_resolver: Optional[GraphQLTypeResolver] = None,
    middleware: Optional[Middleware] = None,
    execution_context_class: Optional[Type["ExecutionContext"]] = None,
) -> AwaitableOrValue[ExecutionResult]:
```
starts to loose readability, but maybe it's time to introduce type aliases for common args; I find the current API great and already useable to be declared stable.